### PR TITLE
Update to axum-core 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ repository = "https://github.com/imbolc/tower-cookies"
 version = "0.3.0"
 
 [features]
-default = ["axum"]
+default = ["axum-core"]
 signed = ["cookie/signed"]
 
 [dependencies]
-axum = { version = "0.3", optional = true }
+async-trait = "0.1"
+axum-core = { version = "0.1", optional = true }
 cookie = { version = "0.15", features = ["percent-encode"] }
 futures-util = "0.3"
 http = "0.2"
@@ -26,7 +27,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 [dev-dependencies]
-axum = "0.3"
+axum = "0.4"
 hyper = "0.14"
 rusty-hook = "0.11"
 tokio = { version = "1", features = ["full"] }
@@ -39,8 +40,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "counter"
-required-features = ["axum"]
+required-features = ["axum-core"]
 
 [[example]]
 name = "hello_world"
-required-features = ["axum"]
+required-features = ["axum-core"]

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,8 +1,6 @@
 use crate::Cookies;
-use axum::{
-    async_trait,
-    extract::{FromRequest, RequestParts},
-};
+use async_trait::async_trait;
+use axum_core::extract::{FromRequest, RequestParts};
 use http::StatusCode;
 
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! use std::net::SocketAddr;
 //! use tower_cookies::{Cookie, CookieManagerLayer, Cookies};
 //!
-//! # #[cfg(feature = "axum")]
+//! # #[cfg(feature = "axum-core")]
 //! #[tokio::main]
 //! async fn main() {
 //!     let app = Router::new()
@@ -22,7 +22,7 @@
 //!         .await
 //!         .unwrap();
 //! }
-//! # #[cfg(not(feature = "axum"))]
+//! # #[cfg(not(feature = "axum-core"))]
 //! # fn main() {}
 //!
 //! async fn handler(cookies: Cookies) -> &'static str {
@@ -58,8 +58,8 @@ pub use cookie::Key;
 
 pub use cookie::Cookie;
 
-#[cfg(feature = "axum")]
-#[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
+#[cfg(feature = "axum-core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "axum-core")))]
 mod extract;
 
 #[cfg(feature = "signed")]
@@ -169,7 +169,7 @@ fn jar_from_str(s: &str) -> CookieJar {
     jar
 }
 
-#[cfg(all(test, feature = "axum"))]
+#[cfg(all(test, feature = "axum-core"))]
 mod tests {
     use crate::{CookieManagerLayer, Cookies};
     use axum::{


### PR DESCRIPTION
This changes `tower-cookies` to have a public dependency on `axum-core`
instead of `axum`.

`axum-core` is designed to be a small crate that only contains the
`FromRequest` and `IntoResponse` traits. Because of the smaller API its
less likely to receive breaking changes. Therefore its recommended for
library to depend on that instead of `axum`.

Note this is a breaking change since `axum` 0.3 doesn't know about
`axum-core`.