### PR TITLE
Fix lifetimes in SignedCookies/PrivateCookies::get()

### DIFF
--- a/src/private.rs
+++ b/src/private.rs
@@ -25,7 +25,7 @@ impl<'a> PrivateCookies<'a> {
     }
 
     /// Returns `Cookie` with the `name` and decrypted contents.
-    pub fn get(&self, name: &str) -> Option<Cookie> {
+    pub fn get(&self, name: &str) -> Option<Cookie<'static>> {
         let mut inner = self.cookies.inner.lock();
         inner.jar().private(self.key).get(name)
     }
@@ -90,10 +90,9 @@ mod tests {
     fn remove() {
         let key = Key::generate();
         let cookies = Cookies::new(vec![]);
-        let cookie = Cookie::new("foo", "bar");
         let private = cookies.private(&key);
-        private.add(cookie.clone());
-        assert!(private.get("foo").is_some());
+        private.add(Cookie::new("foo", "bar"));
+        let cookie = private.get("foo").unwrap();
         private.remove(cookie);
         assert!(private.get("foo").is_none());
     }

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -32,7 +32,7 @@ impl<'a> SignedCookies<'a> {
     /// Returns `Cookie` with the `name` and verifies the authenticity and integrity of the
     /// cookie’s value, returning a `Cookie` with the authenticated value. If the cookie cannot be
     /// found, or the cookie fails to verify, None is returned.
-    pub fn get(&self, name: &str) -> Option<Cookie> {
+    pub fn get(&self, name: &str) -> Option<Cookie<'static>> {
         let mut inner = self.cookies.inner.lock();
         inner.jar().signed(self.key).get(name)
     }
@@ -97,10 +97,9 @@ mod tests {
     fn remove() {
         let key = Key::generate();
         let cookies = Cookies::new(vec![]);
-        let cookie = Cookie::new("foo", "bar");
         let signed = cookies.signed(&key);
-        signed.add(cookie.clone());
-        assert!(signed.get("foo").is_some());
+        signed.add(Cookie::new("foo", "bar"));
+        let cookie = signed.get("foo").unwrap();
         signed.remove(cookie);
         assert!(signed.get("foo").is_none());
     }


### PR DESCRIPTION
Before this commit, the `Key` that's passed to `Cookies::signed()` or `Cookies::private()` is forced to have a static lifetime, because the returned `Cookie` gets `self`'s lifetime as its lifetime parameter.

Fix this by using the cookie `name`'s lifetime instead, and just require it to outlive the lifetime of `self`.

This makes it possible e.g. to store `Key` in an axum `Extension` layer instead of a global `Cell`.