### PR TITLE
Upgrade to axum 0.6.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ private = ["cookie/secure"]
 
 [dependencies]
 async-trait = "0.1"
-axum-core = { version = "0.2", optional = true }
+axum-core = { version = "=0.3.0-rc.2", optional = true }
 cookie = { version = "0.16", features = ["percent-encode"] }
 futures-util = "0.3"
 http = "0.2"
@@ -28,7 +28,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 [dev-dependencies]
-axum = "0.5"
+axum = "=0.6.0-rc.2"
 hyper = "0.14"
 once_cell = "1.9"
 rusty-hook = "0.11"

--- a/examples/counter-extractor.rs
+++ b/examples/counter-extractor.rs
@@ -4,7 +4,8 @@
 //! extractor.
 use async_trait::async_trait;
 use axum::{routing::get, Router};
-use axum_core::extract::{FromRequest, RequestParts};
+use axum_core::extract::FromRequestParts;
+use http::request::Parts;
 use std::net::SocketAddr;
 use tower_cookies::{Cookie, CookieManagerLayer, Cookies};
 
@@ -13,14 +14,14 @@ const COOKIE_NAME: &str = "visited";
 struct Counter(usize);
 
 #[async_trait]
-impl<B> FromRequest<B> for Counter
+impl<S> FromRequestParts<S> for Counter
 where
-    B: Send,
+    S: Send + Sync,
 {
     type Rejection = (http::StatusCode, &'static str);
 
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        let cookies = Cookies::from_request(req).await?;
+    async fn from_request_parts(req: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let cookies = Cookies::from_request_parts(req, state).await?;
 
         let visited = cookies
             .get(COOKIE_NAME)

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,17 +1,17 @@
 use crate::Cookies;
 use async_trait::async_trait;
-use axum_core::extract::{FromRequest, RequestParts};
-use http::StatusCode;
+use axum_core::extract::FromRequestParts;
+use http::{request::Parts, StatusCode};
 
 #[async_trait]
-impl<B> FromRequest<B> for Cookies
+impl<S> FromRequestParts<S> for Cookies
 where
-    B: Send,
+    S: Sync + Send,
 {
     type Rejection = (http::StatusCode, &'static str);
 
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        req.extensions().get::<Cookies>().cloned().ok_or((
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts.extensions.get::<Cookies>().cloned().ok_or((
             StatusCode::INTERNAL_SERVER_ERROR,
             "Can't extract cookies. Is `CookieManagerLayer` enabled?",
         ))


### PR DESCRIPTION
Hi! This is for inspiration, not for merging — axum 0.6 isn't stable yet, I just needed tower-cookies to work with it and thought y'all might be curious to look at what changes will be needed once 0.6 is stable.