### PR TITLE
Update to cookie 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ private = ["cookie/secure"]
 [dependencies]
 async-trait = "0.1"
 axum-core = { version = "0.3", optional = true }
-cookie = { version = "0.16", features = ["percent-encode"] }
+cookie = { version = "0.17", features = ["percent-encode"] }
 futures-util = "0.3"
 http = "0.2"
 parking_lot = "0.12"


### PR DESCRIPTION
Breaking change because cookie is part of the public API.