### PR TITLE
update http to v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,21 +18,23 @@ private = ["cookie/secure"]
 
 [dependencies]
 async-trait = "0.1"
-axum-core = { version = "0.3", optional = true }
+axum-core = { version = "0.4", optional = true }
 cookie = { version = "0.17", features = ["percent-encode"] }
 futures-util = "0.3"
-http = "0.2"
+http = "1.0"
 parking_lot = "0.12"
 pin-project-lite = "0.2"
 tower-layer = "0.3"
 tower-service = "0.3"
 
 [dev-dependencies]
-axum = "0.6"
-hyper = "0.14"
+axum = "0.7"
+hyper = "1.0"
 once_cell = "1.9"
 rusty-hook = "0.11"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7.10", features = ["full"] }
+tokio-stream = { version = "0.1.14", features = ["full"] }
 tower = "0.4"
 tracing-subscriber = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ With [axum]:
 
 ```rust,no_run
 use axum::{routing::get, Router};
-use std::net::SocketAddr;
 use tower_cookies::{Cookie, CookieManagerLayer, Cookies};
 
 #[tokio::main]
@@ -23,11 +22,8 @@ async fn main() {
         .route("/", get(handler))
         .layer(CookieManagerLayer::new());
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn handler(cookies: Cookies) -> &'static str {

--- a/examples/counter-extractor.rs
+++ b/examples/counter-extractor.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use axum::{routing::get, Router};
 use axum_core::extract::FromRequestParts;
 use http::request::Parts;
-use std::net::SocketAddr;
 use tower_cookies::{Cookie, CookieManagerLayer, Cookies};
 
 const COOKIE_NAME: &str = "visited";
@@ -40,11 +39,8 @@ async fn main() {
         .route("/", get(handler))
         .layer(CookieManagerLayer::new());
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn handler(counter: Counter) -> String {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,5 +1,4 @@
 use axum::{routing::get, Router};
-use std::net::SocketAddr;
 use tower_cookies::{Cookie, CookieManagerLayer, Cookies};
 
 const COOKIE_NAME: &str = "visited";
@@ -10,11 +9,8 @@ async fn main() {
         .route("/", get(handler))
         .layer(CookieManagerLayer::new());
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn handler(cookies: Cookies) -> String {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,5 +1,4 @@
 use axum::{routing::get, Router};
-use std::net::SocketAddr;
 use tower_cookies::{Cookie, CookieManagerLayer, Cookies};
 
 #[tokio::main]
@@ -8,11 +7,8 @@ async fn main() {
         .route("/", get(handler))
         .layer(CookieManagerLayer::new());
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn handler(cookies: Cookies) -> &'static str {

--- a/examples/signed_private.rs
+++ b/examples/signed_private.rs
@@ -2,7 +2,6 @@
 //! Can be run by: `cargo run --all-features --example signed_private`
 use axum::{routing::get, Router};
 use once_cell::sync::OnceCell;
-use std::net::SocketAddr;
 use tower_cookies::{Cookie, CookieManagerLayer, Cookies, Key};
 
 const COOKIE_NAME: &str = "visited_private";
@@ -17,11 +16,8 @@ async fn main() {
         .route("/", get(handler))
         .layer(CookieManagerLayer::new());
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn handler(cookies: Cookies) -> String {


### PR DESCRIPTION
This updates the http crate to version 1.0.0 as well as the attendant crates, e.g. axum-core.

The examples are also updated for axum version 0.7, along with hyper.