### PR TITLE
Reduce build dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["imbolc"]
 categories = ["web-programming"]
 description = "Cookie manager middleware for tower."
 edition = "2021"
+rust-version = "1.70"
 homepage = "https://github.com/imbolc/tower-cookies"
 keywords = ["axum", "cookie", "cookies", "tower"]
 license = "MIT"
@@ -29,10 +30,8 @@ tower-service = "0.3"
 
 [dev-dependencies]
 axum = "0.7"
-hyper = "1"
-once_cell = "1.9"
 rusty-hook = "0.11"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 tower = "0.4"
 tracing-subscriber = "0.3"
 http-body-util = "0.1"

--- a/examples/signed_private.rs
+++ b/examples/signed_private.rs
@@ -1,12 +1,12 @@
-//! The counter example using private / signed cookies instead of raw ones
+//! The counter-example using private / signed cookies instead of raw ones
 //! Can be run by: `cargo run --all-features --example signed_private`
 use axum::{routing::get, Router};
-use once_cell::sync::OnceCell;
 use std::net::SocketAddr;
+use std::sync::OnceLock;
 use tower_cookies::{Cookie, CookieManagerLayer, Cookies, Key};
 
 const COOKIE_NAME: &str = "visited_private";
-static KEY: OnceCell<Key> = OnceCell::new();
+static KEY: OnceLock<Key> = OnceLock::new();
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Reduced dev dependencies by:
* Replacing once_cell with `std::lock::OneLock`
* Removing unused dependency on `hyper`
* Simplifying features for `tokio`