### PR TITLE
docs: convey removal instructions from `CookieJar`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,11 @@ impl Cookies {
     }
 
     /// Removes [`Cookie`] from this jar.
+    ///
+    /// **To properly generate the removal cookie, `cookie` must contain the same `path` and
+    /// `domain` as the cookie that was initially set.** In particular, this means that passing a
+    ///  cookie from a browser to this method won't work because browsers don't set the cookie's
+    /// `path` attribute.
     pub fn remove(&self, cookie: Cookie<'static>) {
         let mut inner = self.inner.lock();
         inner.changed = true;

--- a/src/private.rs
+++ b/src/private.rs
@@ -43,6 +43,11 @@ impl<'a> PrivateCookies<'a> {
     }
 
     /// Removes the `cookie` from the parent jar.
+    ///
+    /// **To properly generate the removal cookie, `cookie` must contain the same `path` and
+    /// `domain` as the cookie that was initially set.** In particular, this means that passing a
+    ///  cookie from a browser to this method won't work because browsers don't set the cookie's
+    /// `path` attribute.
     pub fn remove(&self, cookie: Cookie<'static>) {
         self.cookies.remove(cookie);
     }

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -38,6 +38,11 @@ impl<'a> SignedCookies<'a> {
     }
 
     /// Removes the `cookie` from the parent jar.
+    ///
+    /// **To properly generate the removal cookie, `cookie` must contain the same `path` and
+    /// `domain` as the cookie that was initially set.** In particular, this means that passing a
+    ///  cookie from a browser to this method won't work because browsers don't set the cookie's
+    /// `path` attribute.
     pub fn remove(&self, cookie: Cookie<'static>) {
         self.cookies.remove(cookie);
     }


### PR DESCRIPTION
Addresses #34 as a better-than-nothing solution.